### PR TITLE
[FIX] 렌더링 시 신청 버튼 상태 초기화 기능 추가

### DIFF
--- a/src/pages/Chat.jsx
+++ b/src/pages/Chat.jsx
@@ -73,7 +73,7 @@ const Chat = () => {
       setIsApplied(true);
     }
     catch (err) {
-      console.log("신청버튼 오류: ", err);
+      // console.log("신청버튼 오류: ", err);
       alert("이미 완료된 봉사입니다.");
       setIsApplied(true);
     }
@@ -197,43 +197,47 @@ const Chat = () => {
     }
   };
 
-  // 렌더링 시 신청 여부를 ui에 적용용
-  // useEffect(() => {
-  //   const checkApplyStatus = async () => {
-  //     if(!token || !chatroomId) return;
+  //렌더링 시 신청 여부를 ui에 적용용
+  useEffect(() => {
+    const checkApplyStatus = async () => {
+      if(!token || !chatroomId) return;
 
-  //     try {
-  //       const postIdRes = await axios.get(
-  //         `https://halpme.site/api/v1/chatRoom/${chatroomId}/post`,
-  //         {
-  //           headers: { Authorization: `Bearer ${token}`},
-  //           params: { chatroomId: chatroomId },
-  //         }
-  //       );
-  //       const postId = postIdRes.data.data.postId;
-  //       console.log("신청상태 체크 - 포스트 아이디: ", postId);
+      try {
+        const postIdRes = await axios.get(
+          `https://halpme.site/api/v1/chatRoom/${chatroomId}/post`,
+          {
+            headers: { Authorization: `Bearer ${token}`},
+            params: { chatroomId: chatroomId },
+          }
+        );
+        const targetPostId = postIdRes.data.data.postId;
+        console.log("신청상태 체크 - 포스트 아이디: ", targetPostId);
 
-  //       const applyRes = await axios.get(
-  //         `https://halpme.site/api/v1/posts/${postId}/participate`,
-  //         {},
-  //         {
-  //           headers: { Authorization: `Bearer ${token}`},
-  //           params: { postId: postId },
-  //         },
-  //       );
+        const postsRes = await axios.get(
+          `https://halpme.site/api/v1/posts`,
+          {
+            headers: { Authorization: `Bearer ${token}`},
+          }
+        );
+        const postList = postsRes.data.data;
+        const matchedPost = postList.find(post => post.postId === targetPostId)
+        
+        // 아무도 신청하지 않았을 경우, null
+        // 신청하고 난 뒤, AUTHENTICATED
+        console.log("내가 알고 싶은 신청상태값: ", matchedPost.status);
+        if(matchedPost.status === null) setIsApplied(false);
+        else if(matchedPost.status === "AUTHENTICATED") setIsApplied(true);
+        else if(matchedPost.status === "COMPLETED") setIsApplied(true);
 
-  //       console.log("신청상태 체크 - 신청 반환 값: ", applyRes);
+      }
+      catch (err) {
+        console.error("신청 불가 상태: ", err);
+        setIsApplied(true);
+      }
+    };
 
-
-  //     }
-  //     catch (err) {
-  //       console.error("신청 불가 상태: ", err);
-  //       //setIsApplied(true);
-  //     }
-  //   };
-
-  //   checkApplyStatus();
-  // }, [token, chatroomId]);
+    checkApplyStatus();
+  }, [token, chatroomId]);
 
   useEffect(() => {
     adjustHeight();


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
- close #57 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 컴포넌트 렌더링 시점에도 API를 호출하여 신청 가능 여부를 알려주는 기능

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 상태 종류
    - `/api/v1/posts` API를 사용하였을 때 아래와 같이 출력됨
    1. 아무도 신청하지 않음: null
    2. 신청 후: AUTHENTICATED

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
